### PR TITLE
improvement: add `.ash` suffix to the event category

### DIFF
--- a/lib/ash_appsignal.ex
+++ b/lib/ash_appsignal.ex
@@ -13,7 +13,7 @@ defmodule AshAppsignal do
 
     appsignal_span
     |> Appsignal.Span.set_name(name)
-    |> Appsignal.Span.set_attribute("appsignal:category", to_string(type))
+    |> Appsignal.Span.set_attribute("appsignal:category", "#{type}.ash")
 
     :ok
   end


### PR DESCRIPTION
This allows AppSignal to display a breakdown of how much time was spent processing Ash events, and allows us to pick a color for those events.
