### PR TITLE
fix: ensure stop_span/0 always returns :ok

### DIFF
--- a/lib/ash_appsignal.ex
+++ b/lib/ash_appsignal.ex
@@ -44,6 +44,8 @@ defmodule AshAppsignal do
   def stop_span do
     Appsignal.Tracer.current_span()
     |> Appsignal.Tracer.close_span()
+
+    :ok
   end
 
   @impl Ash.Tracer


### PR DESCRIPTION
When there is no active AppSignal span (e.g. in test environments), Appsignal.Tracer.close_span(nil) returns nil rather than :ok. The Ash.Tracer callback requires :ok, so this caused a framework error.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
