### PR TITLE
fix: ensure set_span_context/1 always returns :ok

### DIFF
--- a/lib/ash_appsignal.ex
+++ b/lib/ash_appsignal.ex
@@ -61,6 +61,8 @@ defmodule AshAppsignal do
       register(%{appsignal_span | pid: self()})
       Process.put(:parent_appsignal_span, appsignal_span)
     end
+
+    :ok
   end
 
   @impl Ash.Tracer


### PR DESCRIPTION
The Ash.Tracer callback requires :ok but the if expression was returning nil when appsignal_span is nil, or the return value of Process.put/2.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
